### PR TITLE
Removed broken "base" definition.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,7 @@ function createSourceStream(filename) {
   }
 
   var file = new File(filename ? {
-      cwd: path.dirname(filename)
-    , path: filename
+    path: filename
     , contents: ins
   } : {
     contents: ins


### PR DESCRIPTION
In vinyl "base" does not refer to the _basename_ (i.e. the unqualified file name). Instead it is described as "typically where a glob starts". As it already defaults to "cwd" and we have no meaningful alternative, it should not be set. This solves an issue where paths would be messed up because vinyl-fs will try to write to a nonsensical relative path.
