### PR TITLE
Expose vinyl "base" option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,36 +1,35 @@
-var through2 = require('through2')
-var File = require('vinyl')
-var path = require('path')
+var through2 = require('through2');
+var File = require('vinyl');
+var path = require('path');
 
-module.exports = createSourceStream
+module.exports = function (filename, baseDir) {
+    var ins = through2()
+    var out = false
 
-function createSourceStream(filename) {
-  var ins = through2()
-  var out = false
-
-  if (filename) {
-    filename = path.resolve(filename)
-  }
-
-  var file = new File(filename ? {
-      path: filename
-    , contents: ins
-  } : {
-    contents: ins
-  })
-
-  return through2({
-    objectMode: true
-  }, function(chunk, enc, next) {
-    if (!out) {
-      this.push(file)
-      out = true
+    var opts = {
+        contents: ins
+    };
+    if (filename) {
+        opts.path = path.resolve(baseDir || __dirname, filename);
     }
+    if (baseDir) {
+        opts.base = baseDir;
+    }
+    console.log(opts);
+    var file = new File(opts);
 
-    ins.push(chunk)
-    next()
-  }, function() {
-    ins.push(null)
-    this.push(null)
-  })
+    return through2({
+        objectMode: true
+    }, function(chunk, enc, next) {
+        if (!out) {
+            this.push(file)
+            out = true
+        }
+
+        ins.push(chunk)
+        next()
+    }, function() {
+        ins.push(null)
+        this.push(null)
+    })
 }

--- a/index.js
+++ b/index.js
@@ -1,35 +1,34 @@
-var through2 = require('through2');
-var File = require('vinyl');
-var path = require('path');
+var through2 = require('through2')
+var File = require('vinyl')
+var path = require('path')
 
 module.exports = function (filename, baseDir) {
-    var ins = through2()
-    var out = false
+  var ins = through2()
+  var out = false
 
-    var opts = {
-        contents: ins
-    };
-    if (filename) {
-        opts.path = path.resolve(baseDir || __dirname, filename);
+  var opts = {
+    contents: ins
+  };
+  if (filename) {
+    opts.path = path.resolve(baseDir || __dirname, filename)
+  }
+  if (baseDir) {
+    opts.base = baseDir
+  }
+  var file = new File(opts)
+
+  return through2({
+    objectMode: true
+  }, function(chunk, enc, next) {
+    if (!out) {
+      this.push(file)
+      out = true
     }
-    if (baseDir) {
-        opts.base = baseDir;
-    }
-    console.log(opts);
-    var file = new File(opts);
 
-    return through2({
-        objectMode: true
-    }, function(chunk, enc, next) {
-        if (!out) {
-            this.push(file)
-            out = true
-        }
-
-        ins.push(chunk)
-        next()
-    }, function() {
-        ins.push(null)
-        this.push(null)
-    })
+    ins.push(chunk)
+    next()
+  }, function() {
+    ins.push(null)
+    this.push(null)
+  })
 }


### PR DESCRIPTION
This matches the behavior of `gulp.src()` and is useful for controlling the behavior of `gulp.dest()`. Another option would be to pass through all arguments to vinyl indiscriminately.