### PR TITLE
Populate cwd and base properties of created Vinyl object, just like gulp.src() does.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,20 +4,22 @@ var path = require('path')
 
 module.exports = createSourceStream
 
-function createSourceStream(filename) {
+function createSourceStream(filename, opts) {
   var ins = through2()
   var out = false
 
-  if (filename) {
-    filename = path.resolve(filename)
-  }
+  var spec = {};
 
-  var file = new File(filename ? {
-      path: filename
-    , contents: ins
-  } : {
-    contents: ins
-  })
+  // can have cwd and base overrides, and cwdbase bool to force base to cwd
+  opts = opts || {};
+
+  // populate vinyl cwd and path exactly like gulp.src() would
+  spec.cwd = path.resolve(opts.cwd || process.cwd());
+  spec.path = path.resolve(spec.cwd, filename);
+  spec.base = opts.cwdbase ? spec.cwd : (path.resolve(opts.base || path.dirname(spec.path)));
+  spec.contents = ins;
+
+  var file = new File(spec);
 
   return through2({
     objectMode: true


### PR DESCRIPTION
Since cwd and base are not populated, downstream transforms that rely on them will not work. For example: [gulp-sourcemaps (index.js)](https://github.com/floridoo/gulp-sourcemaps/blob/master/index.js#L218-223)

It appears the first version attempted to populate cwd and base, but then [puma](https://github.com/hughsk/vinyl-source-stream/commits/master/index.js?author=pluma) saw it was not being done correctly, and then completely removed setting them stating they weren't necessary; not true as shown above in gulp-sourcemaps.

There is an open [PR](https://github.com/hughsk/vinyl-source-stream/pull/8) that attempts to populate just base, but it's logic may use [__dirname](http://nodejs.org/docs/latest/api/globals.html#globals_dirname) which is completely wrong as __dirname is based on the source location of the currently executing code!

I looked at exactly how gulp-src() creates vinyl objects, and made changes so vinyl-source-stream can match that behavior, including an optional 'opts' object argument which can contain cwd, base, and cwdbase properties, having the same effect as those options have when passed to gulp.src().
