### PR TITLE
Fix error in Readme with `gulp.dest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ gulp.task('gulpify', function() {
 
 // using vinyl-source-stream:
 gulp.task('browserify', function() {
-  var bundleStream = browserify('index.js').bundle()
+  var bundleStream = browserify('./index.js').bundle()
 
   bundleStream
     .pipe(source('index.js'))

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ var streamify = require('gulp-streamify')
 var browserify = require('browserify')
 var uglify = require('gulp-uglify')
 var gulpify = require('gulpify')
+var rename = require('gulp-rename')
 var gulp = require('gulp')
 
 // using gulpify:
@@ -37,7 +38,8 @@ gulp.task('gulpify', function() {
   gulp.src('index.js')
     .pipe(gulpify())
     .pipe(uglify())
-    .pipe(gulp.dest('./bundle.js'))
+    .pipe(rename('bundle.js'))
+    .pipe(gulp.dest('./'))
 })
 
 // using vinyl-source-stream:
@@ -47,7 +49,8 @@ gulp.task('browserify', function() {
   bundleStream
     .pipe(source('index.js'))
     .pipe(streamify(uglify()))
-    .pipe(gulp.dest('./bundle.js'))
+    .pipe(rename('bundle.js'))
+    .pipe(gulp.dest('./'))
 })
 ```
 


### PR DESCRIPTION
`gulp.dest` aka `vfs.dest` takes a folder path as argument.